### PR TITLE
Fix test for Chicken

### DIFF
--- a/tests/test-0001-Chicken.scm
+++ b/tests/test-0001-Chicken.scm
@@ -26,15 +26,19 @@
 (expect "  12.346" (format "~8,3F" 12.3456))
 (expect "123.346" (format "~6,3F" 123.3456))
 (expect "123.346" (format "~4,3F" 123.3456))
-;(expect "0.000+1.949i" (format "~8,3F" (sqrt -3.8)))
+(cond-expand
+ (chicken-4)
+ (else
+  (expect "0.000+1.949i" (format "~8,3F" (sqrt -3.8)))
+  ))
 (expect " 32.00" (format "~6,2F" 32))
 (expect "    32" (format "~6F" 32))
 ;(expect "   32." (format "~6F" 32.)) ;; "  32.0" OK
 (expect "  32.0" (format "~6F" 32.))
 ;; NB: (not (and (exact? 32.) (integer? 32.)))
-(expect "3.2e+046" (format "~8F" 32e45))
-(expect "3.2e-044" (format "~8F" 32e-45))
-(expect "3.2e+021" (format "~8F" 32e20))
+(expect " 3.2e+46" (format "~8F" 32e45))
+(expect " 3.2e-44" (format "~8F" 32e-45))
+(expect " 3.2e+21" (format "~8F" 32e20))
 ;;(expect "   3.2e6" (format "~8F" 32e5)) ;; ok.  converted in input to 3200000.0
 ;(expect "   3200." (format "~8F" 32e2)) ;; "  3200.0" OK
 (expect "  3200.0" (format "~8F" 32e2))
@@ -42,8 +46,12 @@
 (expect "      1.2345" (format "~12F" 1.2345))
 (expect "        1.23" (format "~12,2F" 1.2345))
 (expect "       1.234" (format "~12,3F" 1.2345))
-;(expect "        0.000+1.949i" (format "~20,3F" (sqrt -3.8)))
-;(expect "0.000+1.949i" (format "~8,3F" (sqrt -3.8)))
+(cond-expand
+ (chicken-4)
+ (else
+  (expect "        0.000+1.949i" (format "~20,3F" (sqrt -3.8)))
+  (expect "0.000+1.949i" (format "~8,3F" (sqrt -3.8)))
+  ))
 (expect "345670000000.00" (format "~8,2F" 3.4567e11))
 ; (expect "#1=(a b c . #1#)"
 ;         (format "~w" (let ( (c '(a b c)) ) (set-cdr! (cddr c) c) c)))
@@ -54,17 +62,17 @@
         (format "~a ~? ~a" 'a "~s" '(new) 'test))
 (expect "a new test, yes!"
         (format "~a ~?, ~a!" 'a "~s ~a" '(new test) 'yes))
-(expect "3.46e+020"  (format "~8,2F" 3.4567e20))
-(expect "3.46e+021"  (format "~8,2F" 3.4567e21))
-(expect "3.46e+022"  (format "~8,2F" 3.4567e22))
-(expect "3.46e+023"  (format "~8,2F" 3.4567e23))
-(expect " 3.e+024"   (format "~8,0F" 3.4567e24))
-(expect "3.5e+024"   (format "~8,1F" 3.4567e24))
-(expect "3.46e+024"  (format "~8,2F" 3.4567e24))
-(expect "3.457e+024" (format "~8,3F" 3.4567e24))
-(expect " 4.e+024"   (format "~8,0F" 3.5567e24))
-(expect "3.6e+024"   (format "~8,1F" 3.5567e24))
-(expect "3.56e+024"  (format "~8,2F" 3.5567e24))
+(expect "3.46e+20"   (format "~8,2F" 3.4567e20))
+(expect "3.46e+21"   (format "~8,2F" 3.4567e21))
+(expect "3.46e+22"   (format "~8,2F" 3.4567e22))
+(expect "3.46e+23"   (format "~8,2F" 3.4567e23))
+(expect "  3.e+24"   (format "~8,0F" 3.4567e24))
+(expect " 3.5e+24"   (format "~8,1F" 3.4567e24))
+(expect "3.46e+24"   (format "~8,2F" 3.4567e24))
+(expect "3.457e+24"  (format "~8,3F" 3.4567e24))
+(expect "  4.e+24"   (format "~8,0F" 3.5567e24))
+(expect " 3.6e+24"   (format "~8,1F" 3.5567e24))
+(expect "3.56e+24"   (format "~8,2F" 3.5567e24))
 (expect "       -0." (format "~10,0F" -3e-4))
 (expect "      -0.0" (format "~10,1F" -3e-4))
 (expect "     -0.00" (format "~10,2F" -3e-4))
@@ -84,7 +92,11 @@
 (expect "    32"     (format "~6F" 32))
 (expect "   32.00"   (format "~8,2F" 32))
 (expect "4321.00"    (format "~1,2F" 4321))
-;(expect "0.00+1.97i" (format "~1,2F" (sqrt -3.9)))
+(cond-expand
+ (chicken-4)
+ (else
+  (expect "0.00+1.97i" (format "~1,2F" (sqrt -3.9)))
+  ))
 (expect "3200000.0"  (format "~8F" 32e5))
 ;(expect "   3.2e6"   (format "~8F" 32e5))
 (expect "<string>"   (format "~h") (lambda (e r) (string? r)))
@@ -100,7 +112,11 @@
 ;(expect "#1=(a b c . #1#)" (format "~w" (let ( (c '(a b c)) ) (set-cdr! (cddr c) c) c)))
 ;(expect "#0=(a b c . #0#)" (format "~w" (let ( (c (list 'a 'b 'c)) ) (set-cdr! (cddr c) c) c)))
 (expect "   32.00"   (format "~8,2F" 32))
-;(expect "0.000+1.949i" (format "~8,3F" (sqrt -3.8)))
+(cond-expand
+ (chicken-4)
+ (else
+  (expect "0.000+1.949i" (format "~8,3F" (sqrt -3.8)))
+  ))
 ;(expect " 3.45e11"   (format "~8,2F" 3.4567e11))
 (expect "345670000000.00" (format "~8,2F" 3.4567e11))
 (expect " 0.333"     (format "~6,3F" 1/3))
@@ -227,14 +243,26 @@
 
 
 (test-section "from mailing list 2004-05-27")
-(expect "1.230e+020" (format "~0,3F" 1.23e20))
-(expect "1.230e-020" (format "~0,3F" 1.23e-20))
+(expect "1.230e+20"  (format "~0,3F" 1.23e20))
+(expect "1.230e-20"  (format "~0,3F" 1.23e-20))
 
 
 (test-section "from mailing list 2004-06-11")
-(expect "3.457e+015" (format "~8,3F" 3.4569e15))
+(cond-expand
+ (chicken-4
+  (expect "3.457e+15" (format "~8,3F" 3.4569e15))
+  )
+ (else
+  (expect "3456900000000000.000" (format "~8,3F" 3.4569e15))
+  ))
 (expect "   3.457"   (format "~8,3F" 3.4569))
-(expect "3.46e+015"  (format "~8,2F" 3.456e15))
+(cond-expand
+ (chicken-4
+  (expect "3.46e+15"  (format "~8,2F" 3.456e15))
+  )
+ (else
+  (expect "3456000000000000.00"  (format "~8,2F" 3.456e15))
+  ))
 (expect "    3.46"   (format "~8,2F" 3.456))
 
 
@@ -244,7 +272,7 @@
 (expect "     -0.00" (format "~10,2F" -3e-4))
 (expect "    -0.000" (format "~10,3F" -3e-4))
 (expect "   -0.0003" (format "~10,4F" -3e-4))
-(expect "3.0000e-005" (format "~10,4F"  3e-5))
+(expect "3.0000e-05" (format "~10,4F"  3e-5))
 
 
 (test-section "from mailing list 2005-06-07")


### PR DESCRIPTION
I tested on Chicken 5.2.0 and Chicken 4.12.0 .

If it works well, I will update the github master of srfi-48 too.

NOTE:

- SRFI-48 reference implementation uses three procedures for format ~F .
  https://github.com/scheme-requests-for-implementation/srfi-48/blob/25c523e1b234e646a60c7c6c7e473f422ef396a5/test/srfi-48.scm#L11
  And, they use number->string, exact->inexact and inexact->exact in them.
  So, the output is dependent on these procedures.

- Chicken 5 seems to support complex numbers by default.

- Chicken 4 and 5 seem to have the different number of digits that changes
  from fixed-point notation to exponential notation by number->string .
  
  ```
  ;; Chicken 5
  (number->string 3.4569e15) ; ==> "3456900000000000.0"
  (number->string 3.456e15)  ; ==> "3456000000000000.0"
  
  ;; Chicken 4
  (number->string 3.4569e15) ; ==> "3.4569e+15"
  (number->string 3.456e15)  ; ==> "3.456e+15"
  ```
